### PR TITLE
Add curator app int test and search epadd dropbox

### DIFF
--- a/env-example.txt
+++ b/env-example.txt
@@ -6,11 +6,12 @@ APP_LOG_LEVEL=INFO
 
 DIMS_ENDPOINT=https://ltsds-cloud-dev-1.lib.harvard.edu:10580
 DTS_ENDPOINT=https://ltsds-cloud-dev-1.lib.harvard.edu:10581
-DROPBOX_DESTINATION=/drs2dev/drsfs/dropbox/dvndev/incoming
+BASE_DROPBOX_PATH=/drs2dev/drsfs/dropbox
 
 # Dataverse Vars
 DATAVERSE_ENDPOINT=http://dvn-dev-hdc.lib.harvard.edu
 ADMIN_USER_API_TOKEN=
+DATAVERSE_DROPBOX=dvndev
 
 # Transfer Queue
 MQ_TRANSFER_HOST=dev_activemq
@@ -19,8 +20,6 @@ MQ_TRANSFER_USER=ims
 MQ_TRANSFER_PASSWORD=XXX
 MQ_TRANSFER_QUEUE_TRANSFER_READY=/queue/transfer-ready
 
-# S3 Creds
-S3_BUCKET_NAME=
-#Read-Write Credentials
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
+# ePADD Curator App
+CURATOR_APP_ENDPOINT=http://ltsds-cloud-dev-1.lib.harvard.edu:10586
+EPADD_DROPBOX=epadddev_secure

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,3 @@ structlog==20.1.0
 stomp.py==7.0.0
 urllib3==1.26.5
 Werkzeug==1.0.1
-glob==3.10.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ structlog==20.1.0
 stomp.py==7.0.0
 urllib3==1.26.5
 Werkzeug==1.0.1
+glob==3.10.7


### PR DESCRIPTION
**Add curator app int test and search epadd dropbox**
* * *

**JIRA Ticket**: [epadd#101](https://app.zenhub.com/workspaces/epadd-harvard-62c485cd49f954001312ebdd/issues/harvard-lts/epadd/101) [epadd#61](https://app.zenhub.com/workspaces/epadd-harvard-62c485cd49f954001312ebdd/issues/harvard-lts/epadd/61)

# What does this Pull Request do?
This PR adds an endpoint to place a test epadd export in the nextcloud s3 buckets to kick off a test. It adds the epadd dropbox to check for successful ingest.

# How should this be tested?

1. Deploy to dev (already deployed)
2. Call `https://ltsds-cloud-dev-1.lib.harvard.edu:10582/curatorApp/publishExport`
3. Confirm a test export was placed in the nextcloud dev bucket at `test/`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n/a
- integration tests? yes

# Interested parties
@ives1227 