### PR TITLE
ePADD Performance tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,5 @@
 // intTestEndpoints: List of integration test endpoints i.e. ['healthcheck/', 'another/example/']
 // default values: slackChannel = "lts-jenkins-notifications"
 
-def endpoints = []
+def endpoints = ["curatorApp/testbatch/ePADD-eml-export", "curatorApp/testbatch/ePADD-mbox-export"]
 ltsBasicPipeline.call("int-tests", "DAIS", "hdc3a", "10582", endpoints, "hdc-3a")

--- a/app/resources.py
+++ b/app/resources.py
@@ -104,6 +104,26 @@ def define_resources(app):
                                                                                          test_batch_name + "in dropbox " + os.path.join(
                 base_dropbox_path, "lts_load_reports", epadd_dropbox)}
         return json.dumps(result)
+    
+        
+    @app.route('/curatorApp/testbatch/<batchName>')
+    def curator_app_performance_test(batchName):
+        curator_app_endpoint = os.getenv("CURATOR_APP_ENDPOINT")
+        url = os.path.join(curator_app_endpoint, "runTest", batchName)
+        result = {"num_failed": 0, "tests_failed": [], "info": {}}
+        app.logger.debug("Calling {}".format(url))
+        response = requests.get(url, verify=False)
+        app.logger.debug("RESPONSE")
+        app.logger.debug(response)
+        json_response = response.json()
+        if json_response["status"] != "success":
+            result["num_failed"] = 1
+            result["tests_failed"].append("Curator App testing batch " + batchName)
+            return json.dumps(result)
+        
+        result["info"]["Curator App Performance Test: "+batchName] = {"status_code": response.status_code}
+
+        return json.dumps(result)
 
     @app.route('/DVIngest/createDataset')
     def dv_ingest_create_dataset():
@@ -234,3 +254,4 @@ def define_resources(app):
                                                                            batchName + "in dropbox " + os.path.join(
                 base_dropbox_path, dataverse_dropbox)}
         return json.dumps(result)
+


### PR DESCRIPTION
**Adds a call to the epadd-curator-app performance tests **
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/LTSEPADD-74

# What does this Pull Request do?
Adds a call to the epadd-curator-app performance tests mentioned in the Jenkins endpoint array

# How should this be tested?

Locally:

1. Follow the instructions on how to spin up this locally: https://github.com/harvard-lts/dais-integration-tests#local-development-environment-setup-instructions
2. From a browser, call `https://localhost:10582/curatorApp/testbatch/ePADD-eml-export` which will trigger the performance test.  
3. Check DRS Web Admin Dev in 5-10 minutes for the opaque container


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no

# Interested parties
@jessjass 